### PR TITLE
Fixed fetching leagues schedule in first month

### DIFF
--- a/handlers/leagues.js
+++ b/handlers/leagues.js
@@ -13,7 +13,7 @@ Dota2.Dota2Client.prototype.leaguesInMonthRequest = function(month, year, callba
   callback = callback || null;
 
   // Month & year default to current time values
-  month = month || (new Date()).getMonth();
+  month = month === undefined ? (new Date()).getMonth() : month;
   year = year || (new Date()).getFullYear();
 
   /* Sends a message to the Game Coordinator requesting the data on the given month's leagues.


### PR DESCRIPTION
If we want to fetch schedule for January we will receive result for current month instead of required
