### PR TITLE
Use the latest Steam library

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "merge": ">= 0.0.2"
   },
   "peerDependencies": {
-    "steam": ">= 0.6.0"
+    "steam": ">= 0.6.6"
   },
   "readmeFilename": "README.md",
   "description": "A node-steam plugin for Dota 2.",


### PR DESCRIPTION
https://github.com/RJacksonm1/node-dota2/issues/36

The old Steam library uses the new crc library that dropped support for Buffers.

This Steam version should probably be tested before it is used by default.
