### PR TITLE
Fixed crash when invoking Dota2Client.exit()

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,8 @@ Dota2Client.prototype.exit = function() {
       this._gcClientHelloIntervalId = null;
   }
   this._gcReady = false;
-  this._client.gamesPlayed([]);
+  
+  if(this._client.loggedOn) this._client.gamesPlayed([]);
 };
 
 


### PR DESCRIPTION
The crash happens when `Dota2Client.exit()` is invoked while the Steam client is not loggedOn. Specifically, attempting to invoke `Steam.gamesPlayed()` while not loggedOn.

As described in #21
