### PR TITLE
match.js: requestMatchDetails() and requestMatchMinimalDetails() now correctly use `this.debug`

### DIFF
--- a/handlers/match.js
+++ b/handlers/match.js
@@ -110,8 +110,7 @@ var onMatchDetailsResponse = function onMatchDetailsResponse(message, callback) 
     var matchDetailsResponse = Dota2.schema.CMsgGCMatchDetailsResponse.decode(message);
 
     if (matchDetailsResponse.result === 1) {
-        /*if (this.debug)*/
-        util.log("Received match data for: " + matchDetailsResponse.match.match_id);
+        if (this.debug) util.log("Received match data for: " + matchDetailsResponse.match.match_id);
         this.emit("matchDetailsData",
             matchDetailsResponse.match.match_id,
             matchDetailsResponse);
@@ -128,8 +127,7 @@ var onMatchMinimalDetailsResponse = function onMatchMinimalDetailsResponse(messa
     var matchMinimalDetailsResponse = Dota2.schema.CMsgClientToGCMatchesMinimalResponse.decode(message);
 
     if (matchMinimalDetailsResponse.matches) {
-        /*if (this.debug)*/
-        util.log("Received match minimal data for: " + matchMinimalDetailsResponse.matches.match_id);
+        if (this.debug) util.log("Received match minimal data for: " + matchMinimalDetailsResponse.matches.match_id);
         this.emit("matchMinimalDetailsData",
             matchMinimalDetailsResponse.last_match,
             matchMinimalDetailsResponse);


### PR DESCRIPTION
Since 46f182e99b0b4f97b7d5dc32f556930a887ff57e the debug switch for `requestMatchDetails()` was [commented out](https://github.com/Arcana/node-dota2/commit/46f182e99b0b4f97b7d5dc32f556930a887ff57e#diff-e9eea5b23b549805939a6429f2d0529cR58). This then got copied to `requestMinimalMatchDetails()` and now both methods always print the debug message no matter what flags are set.

I just enabled the debug switch again, should be fine now.