### PR TITLE
In-game items, player card stuff & node js deprecation fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "7.0.0"
+  - "7.2.0"
   - "6.9.1"

--- a/examples/example.js
+++ b/examples/example.js
@@ -15,7 +15,7 @@ global.config = require("./config");
 var onSteamLogOn = function onSteamLogOn(logonResp) {
         if (logonResp.eresult == steam.EResult.OK) {
             steamFriends.setPersonaState(steam.EPersonaState.Busy); // to display your steamClient's status as "Online"
-            steamFriends.setPersonaName("dhdeubot"); // to change its nickname
+            steamFriends.setPersonaName(global.config.steam_name); // to change its nickname
             util.log("Logged on.");
             Dota2.launch();
             Dota2.on("ready", function() {
@@ -146,20 +146,23 @@ var onSteamLogOn = function onSteamLogOn(logonResp) {
                 // Dota2.setGuildAccountRole(guildId, 75028261, 3);
             });
             Dota2.on("unhandled", function(kMsg) {
-                util.log("UNHANDLED MESSAGE " + kMsg);
+                util.log("UNHANDLED MESSAGE " + dota2._getMessageName(kMsg));
             });
             // setTimeout(function(){ Dota2.exit(); }, 5000);
         }
     },
     onSteamServers = function onSteamServers(servers) {
         util.log("Received servers.");
-        fs.writeFile('servers', JSON.stringify(servers));
+        fs.writeFile('servers', JSON.stringify(servers), (err)=>{
+            if (err) {if (this.debug) util.log("Error writing ");}
+            else {if (this.debug) util.log("");}
+        });
     },
     onSteamLogOff = function onSteamLogOff(eresult) {
         util.log("Logged off from Steam.");
     },
     onSteamError = function onSteamError(error) {
-        util.log("Connection closed by server.");
+        util.log("Connection closed by server: "+error);
     };
 
 steamUser.on('updateMachineAuth', function(sentry, callback) {
@@ -177,7 +180,7 @@ var logOnDetails = {
     "account_name": global.config.steam_user,
     "password": global.config.steam_pass,
 };
-if (global.config.steam_guard_code) logOnDetails.auth_code = global.config.steam_guard_code;
+if (global.config.two_factor_code) logOnDetails.two_factor_code = global.config.two_factor_code;
 
 try {
     var sentry = fs.readFileSync('sentry');

--- a/handlers/cache.js
+++ b/handlers/cache.js
@@ -31,30 +31,37 @@ var cacheTypeIDs = {
 // Handlers
 function handleSubscribedType(obj_type, object_data) {
     switch (obj_type) {
+        // Inventory item
+        case cacheTypeIDs.CSOEconItem:
+            if (this.debug) util.log("Received inventory snapshot");
+            var inv = object_data.map(obj => Dota2.schema.CSOEconItem.decode(obj));
+            this.emit("inventoryUpdate", inv);
+            this.Inventory = inv;
+            break;
         // Lobby snapshot.
         case cacheTypeIDs.CSODOTALobby:
-            var lobby = Dota2.schema.CSODOTALobby.decode(object_data);
+            var lobby = Dota2.schema.CSODOTALobby.decode(object_data[0]);
             if (this.debug) util.log("Received lobby snapshot for lobby ID " + lobby.lobby_id);
             this.emit("practiceLobbyUpdate", lobby);
             this.Lobby = lobby;
             break;
         // Lobby invite snapshot.
         case cacheTypeIDs.CSODOTALobbyInvite:
-            var lobby = Dota2.schema.CSODOTALobbyInvite.decode(object_data);
+            var lobby = Dota2.schema.CSODOTALobbyInvite.decode(object_data[0]);
             if (this.debug) util.log("Received lobby invite snapshot for group ID " + lobby.group_id);
             this.emit("lobbyInviteUpdate", lobby);
             this.LobbyInvite = lobby;
             break;
         // Party snapshot.
         case cacheTypeIDs.CSODOTAParty:
-            var party = Dota2.schema.CSODOTAParty.decode(object_data);
+            var party = Dota2.schema.CSODOTAParty.decode(object_data[0]);
             if (this.debug) util.log("Received party snapshot for party ID " + party.party_id);
             this.emit("partyUpdate", party);
             this.Party = party;
             break;
         // Party invite snapshot.
         case cacheTypeIDs.CSODOTAPartyInvite:
-            var party = Dota2.schema.CSODOTAPartyInvite.decode(object_data);
+            var party = Dota2.schema.CSODOTAPartyInvite.decode(object_data[0]);
             if (this.debug) util.log("Received party invite snapshot for group ID " + party.group_id);
             this.emit("partyInviteUpdate", party);
             this.PartyInvite = party;
@@ -84,11 +91,11 @@ var onCacheSubscribed = function onCacheSubscribed(message) {
     var _self = this;
 
     if (this.debug) {
-        util.log("Cache subscribed, type " + subscribe.objects[0].type_id);
+        util.log("Cache(s) subscribed, type(s): " + subscribe.objects.map(obj=>obj.type_id).toString());
     }
 
     subscribe.objects.forEach(function(obj) {
-        handleSubscribedType.call(_self, obj.type_id, obj.object_data[0]);
+        handleSubscribedType.call(_self, obj.type_id, obj.object_data);
     });
 };
 handlers[Dota2.schema.ESOMsg.k_ESOMsg_CacheSubscribed] = onCacheSubscribed;

--- a/handlers/fantasy.js
+++ b/handlers/fantasy.js
@@ -1,0 +1,94 @@
+var Dota2 = require("../index"),
+    util = require("util");
+
+// Methods
+// // This proto message is not supported by Valve's backend as of yet
+// Dota2.Dota2Client.prototype.requestPlayerCardItemInfo = function(player_card_ids, callback) {
+//     player_card_ids = player_card_ids.constructor == Array ? player_card_ids : [player_card_ids];
+//     callback = callback || null;
+//     var _self = this;
+    
+//     /* Sends a message to the Game Coordinator requesting information on a list of player card ID's. Listen for `playerCardInfo` event for Game Coordinator's response. */
+//     if (this.debug) util.log("Requesting player card info");
+
+//     var payload = new Dota2.schema.CMsgGCGetPlayerCardItemInfo({
+//         "account_id": this.AccountID,
+//         "player_card_item_ids": player_card_ids
+//     });
+    
+//     this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCGetPlayerCardItemInfo, 
+//                     payload, 
+//                     onPlayerCardInfoResponse, callback);
+// }
+
+Dota2.Dota2Client.prototype.requestPlayerCardRoster = function(league_id, timestamp, callback) {
+    callback = callback || null;
+    var _self = this;
+    
+    /* Sends a message to the Game Coordinator requesting information on a list of player card ID's. Listen for `playerCardInfo` event for Game Coordinator's response. */
+    if (this.debug) util.log("Requesting player card roster");
+
+    var payload = new Dota2.schema.CMsgClientToGCGetPlayerCardRosterRequest({
+        "league_id": league_id,
+        "timestamp": timestamp
+    });
+    
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgClientToGCGetPlayerCardRosterRequest, 
+                    payload, 
+                    onGetPlayerCardRosterResponse, callback);
+}
+
+Dota2.Dota2Client.prototype.draftPlayerCard = function(league_id, timestamp, slot, player_card_id, callback) {
+    callback = callback || null;
+    var _self = this;
+    
+    /* Sends a message to the Game Coordinator requesting information on a list of player card ID's. Listen for `playerCardInfo` event for Game Coordinator's response. */
+    if (this.debug) util.log("Requesting player card roster");
+
+    var payload = new Dota2.schema.CMsgClientToGCSetPlayerCardRosterRequest({
+        "league_id": league_id,
+        "timestamp": timestamp
+    });
+    
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgClientToGCSetPlayerCardRosterRequest, 
+                    payload, 
+                    onSetPlayerCardRosterResponse, callback);
+}
+
+
+// Handlers
+var handlers = Dota2.Dota2Client.prototype._handlers;
+
+// // This proto message is not supported by Valve's backend as of yet
+// var onPlayerCardInfoResponse = function onPlayerCardInfoResponse(message, callback) {
+//     callback = callback || null;
+//     var playerCardInfo = Dota2.schema.CMsgGCGetPlayerCardItemInfoResponse.decode(message);
+//     if (this.debug) util.log("Received info for player cards");
+//     this.emit("playerCardInfo", playerCardInfo.player_card_infos);
+//     if (callback) callback(null, playerCardInfo);
+    
+// };
+// handlers[Dota2.schema.EDOTAGCMsg.k_EMsgClientToGCCreatePlayerCardPackResponse] = onPlayerCardInfoResponse;
+
+var onGetPlayerCardRosterResponse = function onGetPlayerCardRosterResponse(message, callback) {
+    callback = callback || null;
+    var playerCardRoster = Dota2.schema.CMsgClientToGCGetPlayerCardRosterResponse.decode(message);
+    if (playerCardRoster.result == 0) {
+        if (this.debug) util.log("Received roster for player cards");
+        this.emit("playerCardRoster", playerCardRoster);
+        if (callback) callback(null, playerCardRoster);
+    } else {
+        if (this.debug) util.log("Error receiving roster for player cards: " + playerCardRoster.result);
+        if (callback) callback(playerCardRoster.result);
+    }
+};
+handlers[Dota2.schema.EDOTAGCMsg.k_EMsgClientToGCGetPlayerCardRosterResponse] = onGetPlayerCardRosterResponse;
+
+var onSetPlayerCardRosterResponse = function onSetPlayerCardRosterResponse(message, callback) {
+    callback = callback || null;
+    var playerCardRoster = Dota2.schema.CMsgClientToGCSetPlayerCardRosterResponse.decode(message);
+    if (this.debug) util.log("Received player card draft result: "+playerCardRoster.result);
+    this.emit("playerCardDrafted", playerCardRoster.result);
+    if (callback) callback(playerCardRoster.result);
+};
+handlers[Dota2.schema.EDOTAGCMsg.k_EMsgClientToGCSetPlayerCardRosterResponse] = onSetPlayerCardRosterResponse;

--- a/handlers/fantasy.js
+++ b/handlers/fantasy.js
@@ -1,7 +1,68 @@
 var Dota2 = require("../index"),
-    util = require("util");
+    util = require("util"),
+    Long = require('long');
 
 // Methods
+
+// Returns a list of promises which resolve to a list of players, with player stats if the call to the GC was succesful.
+// Maximum delay before promises resolve is ~20s. 
+// A player object looks like this:
+// {
+//     'account_id' : uint32,
+//     'cards' : [{'id' : uint32, 'bonuses' : uint64}],
+//     'stats' : CMsgGCToClientPlayerStatsResponse (if GC responded before 2s timeout)
+// }
+// For magic numbers, see -> https://raw.githubusercontent.com/SteamDatabase/GameTracking/master/dota/game/dota/pak01_dir/scripts/items/items_game.txt
+Dota2.Dota2Client.prototype.requestPlayerCardsByPlayer = function() {
+    if(this.Inventory) {
+        var playercards = this.Inventory.filter(item => item.def_index == 11953);
+        var promises = [];
+        // Sort cards per player
+        var players = playercards.reduce((players, card)=>{
+            var id_attr = card.attribute.filter(attr => attr.def_index == 424)[0];
+            var account_id = Buffer.from(id_attr.value_bytes.buffer).readUInt32LE(id_attr.value_bytes.offset);
+            // Add player if we haven't seen him yet
+            if (!players[account_id]) players[account_id] = {'account_id': account_id, 'cards': []};
+            // Add this card
+            var bonus = card.attribute.filter(attr => attr.def_index == 425)[0];
+            players[account_id].cards.push({
+                'id': card.id,
+                'bonuses': bonus ?  new Long(Buffer.from(bonus.value_bytes.buffer).readUInt32LE(bonus.value_bytes.offset + 4),
+                                    Buffer.from(bonus.value_bytes.buffer).readUInt32LE(bonus.value_bytes.offset), 
+                                    true)
+                                :   undefined
+            });
+            return players;
+        },{});
+        // Send a player stats request for each player account id
+        Object.keys(players).forEach((player, i)=>{
+            promises.push(
+                new Promise((resolve, reject) => {
+                    // Stagger the requests with 200ms intervals
+                    setTimeout(() =>{
+                        this.requestPlayerStats(players[player].account_id, (err, result) => {
+                            if (err) return reject(err);
+                            return resolve(
+                                (() => {
+                                    players[player].stats = result;
+                                    return players[player];
+                                })()
+                            );
+                        });
+                        // Resolve if we haven't received a response after 2s
+                        setTimeout(()=>resolve(players[player]), 2000);
+                    }, i * 200);
+                })
+                
+            );
+        });
+        
+        return promises;
+    } else {
+        return null;
+    }
+}
+
 // // This proto message is not supported by Valve's backend as of yet
 // Dota2.Dota2Client.prototype.requestPlayerCardItemInfo = function(player_card_ids, callback) {
 //     player_card_ids = player_card_ids.constructor == Array ? player_card_ids : [player_card_ids];

--- a/handlers/fantasy.js
+++ b/handlers/fantasy.js
@@ -20,17 +20,14 @@ Dota2.Dota2Client.prototype.requestPlayerCardsByPlayer = function() {
         // Sort cards per player
         var players = playercards.reduce((players, card)=>{
             var id_attr = card.attribute.filter(attr => attr.def_index == 424)[0];
-            var account_id = Buffer.from(id_attr.value_bytes.buffer).readUInt32LE(id_attr.value_bytes.offset);
+            var account_id = id_attr.value_bytes.readUInt32(id_attr.value_bytes.offset);
             // Add player if we haven't seen him yet
             if (!players[account_id]) players[account_id] = {'account_id': account_id, 'cards': []};
             // Add this card
             var bonus = card.attribute.filter(attr => attr.def_index == 425)[0];
             players[account_id].cards.push({
                 'id': card.id,
-                'bonuses': bonus ?  new Long(Buffer.from(bonus.value_bytes.buffer).readUInt32LE(bonus.value_bytes.offset + 4),
-                                    Buffer.from(bonus.value_bytes.buffer).readUInt32LE(bonus.value_bytes.offset), 
-                                    true)
-                                :   undefined
+                'bonuses': bonus ?  bonus.value_bytes.readUInt64(bonus.value_bytes.offset) : undefined
             });
             return players;
         },{});

--- a/index.js
+++ b/index.js
@@ -112,6 +112,7 @@ Dota2Client.prototype.launch = function() {
     this.Party = null;
     this.Lobby = null;
     this.PartyInvite = null;
+    this.Inventory = null;
     this._user.gamesPlayed([{
         "game_id": this._appid
     }]);
@@ -227,3 +228,4 @@ require("./handlers/sourcetv");
 require("./handlers/team");
 require("./handlers/custom");
 require("./handlers/general");
+require("./handlers/fantasy");


### PR DESCRIPTION
Had to rework the way the SO caches are decoded a bit, since the original implementation made assumptions on their contents which only hold for lobbies and chats.
For the fantasy stuff, I implemented `CMsgGCGetPlayerCardItemInfo`, but GC ignores it completely. I've left the code in comments for future reference. To get the player card information, check your inventory for items with `def_index: 11953`. Their id can be used in the fantasy methods, their attribute with `def_index: 424` contains the account_id of the player and the attribute with `def_index: 425` contains the information about the card type (bonuses etc.). 
I'll probably look into creating a helper method to extract the relevant information somewhere in the coming days/weeks, but if someone could take a look at this already, that'd be great.