### PR TITLE
Fix #390

### DIFF
--- a/handlers/cache.js
+++ b/handlers/cache.js
@@ -40,7 +40,9 @@ function handleSubscribedType(obj_type, object_data) {
             break;
         // Lobby snapshot.
         case cacheTypeIDs.CSODOTALobby:
-            var lobby = Dota2.schema.CSODOTALobby.decode(object_data[0]);
+            // object_data is an array when called from onCacheSubscribed
+            // but an object when called from onUpdateMultiple
+            var lobby = Dota2.schema.CSODOTALobby.decode([].concat(object_data)[0]);
             if (this.debug) util.log("Received lobby snapshot for lobby ID " + lobby.lobby_id);
             this.emit("practiceLobbyUpdate", lobby);
             this.Lobby = lobby;
@@ -54,7 +56,7 @@ function handleSubscribedType(obj_type, object_data) {
             break;
         // Party snapshot.
         case cacheTypeIDs.CSODOTAParty:
-            var party = Dota2.schema.CSODOTAParty.decode(object_data[0]);
+            var party = Dota2.schema.CSODOTAParty.decode([].concat(object_data)[0]);
             if (this.debug) util.log("Received party snapshot for party ID " + party.party_id);
             this.emit("partyUpdate", party);
             this.Party = party;


### PR DESCRIPTION
Resolution for #390. Not the nicest fix I've ever written, but I don't see how I could do it better. Since the CSODOTALobby handler can be called with an array or an object, I need to perform some tweaking to get an object in both cases (if only the spread operator left non-iterable objects alone instead of crashing :disappointed: )