### PR TITLE
Fix lookupEnum not being used on handlers/lobbies.js

### DIFF
--- a/handlers/lobbies.js
+++ b/handlers/lobbies.js
@@ -327,7 +327,7 @@ var onPracticeLobbyJoinResponse = function onPracticeLobbyJoinResponse(message, 
     this.emit("practiceLobbyJoinResponse", practiceLobbyJoinResponse.result, practiceLobbyJoinResponse);
     
     if (callback) {
-        if (practiceLobbyJoinResponse.result === Dota2.schema.DOTAJoinLobbyResult.DOTA_JOIN_RESULT_SUCCESS) {
+        if (practiceLobbyJoinResponse.result === Dota2.schema.lookupEnum("DOTAJoinLobbyResult").DOTA_JOIN_RESULT_SUCCESS) {
             callback(null, practiceLobbyJoinResponse);
         } else {
             callback(practiceLobbyJoinResponse.result, practiceLobbyJoinResponse);


### PR DESCRIPTION
This would throw a ReferenceError ("can't read property DOTAJoinLobbyResult of Dota2.schema" IIRC) when using the method `joinPracticeLobbyTeam()` or `joinPracticeLobbyBroadcastChannel()`.