### PR TITLE
Fix protobufjs dependency to ~6.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "long": "^3.0.0",
     "deferred": "^0.7.2",
     "merge": "^1.2.0",
-    "protobufjs": "^6.0.0",
+    "protobufjs": "~6.6.0",
     "steam": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi,

Protobufjs released a new version (6.7.0) which breaks node-dota2.

Symptoms:

Running the example is stuck in a `Sending ClientHello` loop.