### PR TITLE
Fix null pointer on onOtherJoinedChannel

### DIFF
--- a/handlers/chat.js
+++ b/handlers/chat.js
@@ -279,7 +279,7 @@ var onOtherJoinedChannel = function onOtherJoinedChannel(message) {
     /* Someone joined a chat channel you're in. */
     var otherJoined = Dota2.schema.lookupType("CMsgDOTAOtherJoinedChatChannel").decode(message);
     var channel = this._getChannelById(otherJoined.channel_id);
-    this.Logger.debug(otherJoined.steam_id + " joined channel " + channel.channel_name);
+    this.Logger.debug(otherJoined.steam_id + " joined channel " + channel ? channel.channel_name : " unknown");
     this.emit("chatJoin",
         channel.channel_name,
         otherJoined.persona_name,

--- a/handlers/chat.js
+++ b/handlers/chat.js
@@ -278,8 +278,11 @@ handlers[Dota2.schema.lookupEnum("EDOTAGCMsg").values.k_EMsgGCChatMessage] = onC
 var onOtherJoinedChannel = function onOtherJoinedChannel(message) {
     /* Someone joined a chat channel you're in. */
     var otherJoined = Dota2.schema.lookupType("CMsgDOTAOtherJoinedChatChannel").decode(message);
-    var channel = this._getChannelById(otherJoined.channel_id);
-    this.Logger.debug(otherJoined.steam_id + " joined channel " + channel ? channel.channel_name : " unknown");
+    var channel = this._getChannelById(otherJoined.channel_id) || {
+        channel_name: "Unknown",
+        members: []
+    };
+	this.Logger.debug(otherJoined.steam_id + " joined channel " + channel.channel_name);
     this.emit("chatJoin",
         channel.channel_name,
         otherJoined.persona_name,


### PR DESCRIPTION
Hi there!

This is related to #291 and #293 and has been crashing my bots non-stop for the past few days. I'm not sure why it happens, since I make sure to leave chat channels and lobbies before terminating my bots. I leave the chat with this line (maybe I'm missing something):

```javascript
super.leaveChat(this.lobby.chatChannel, ChatChannelType.DOTAChannelType_Lobby)
// super refers to Dota2Client since I extend it.
```

Anyways, a null pointer has been crashing my bots:

```
TypeError: Cannot read property 'channel_name' of undefined 
    at DotaClientX.onOtherJoinedChannel (/app/node_modules/dota2/handlers/chat.js:282:74) 
    at SteamGameCoordinator.fromGC (/app/node_modules/dota2/index.js:167:38) 
    at emitThree (events.js:135:13) 
    at SteamGameCoordinator.emit (events.js:216:7) 
    at SteamGameCoordinator.handlers.(anonymous function) (/app/node_modules/steam/lib/handlers/game_coordinator/index.js:107:10) 
    at SteamGameCoordinator.<anonymous> (/app/node_modules/steam/lib/handlers/game_coordinator/index.js:19:28) 
    at emitThree (events.js:140:20) 
    at SteamClient.emit (events.js:216:7) 
    at SteamClient._netMsgReceived (/app/node_modules/steam/lib/steam_client.js:172:10) 
    at SteamClient.handlers.(anonymous function) (/app/node_modules/steam/lib/steam_client.js:259:10) 
    at SteamClient._netMsgReceived (/app/node_modules/steam/lib/steam_client.js:157:26) 
    at emitOne (events.js:115:13) 
    at Connection.emit (events.js:210:7) 
    at Connection._readPacket (/app/node_modules/steam/lib/connection.js:50:8) 
    at emitNone (events.js:105:13) 
    at Connection.emit (events.js:207:7) 
    at emitReadable_ (_stream_readable.js:516:10) 
    at emitReadable (_stream_readable.js:510:7) 
    at addChunk (_stream_readable.js:277:7) 
    at readableAddChunk (_stream_readable.js:253:11) 
    at Connection.Readable.push (_stream_readable.js:211:10) 
    at TCP.onread (net.js:585:20)
```

This PR should fix it.
