### PR TITLE
Channel undefined handling in onChatMessage event handler

### DIFF
--- a/handlers/chat.js
+++ b/handlers/chat.js
@@ -264,11 +264,9 @@ handlers[Dota2.schema.lookupEnum("EDOTAGCMsg").values.k_EMsgGCJoinChatChannelRes
 var onChatMessage = function onChatMessage(message) {
     /* Chat channel message from another user. */
     var chatData = Dota2.schema.lookupType("CMsgDOTAChatMessage").decode(message);
-    var channel = this._getChannelById(chatData.channel_id);
-
-    if (!channel) {
-        channel = { channel_name: "Unknown" }
-    }
+    var channel = this._getChannelById(chatData.channel_id) || {
+        channel_name: "Unknown"
+    };
 
     this.Logger.debug("Received chat message from " + chatData.persona_name + " in channel " + channel.channel_name);
     this.emit("chatMessage",

--- a/handlers/chat.js
+++ b/handlers/chat.js
@@ -266,6 +266,10 @@ var onChatMessage = function onChatMessage(message) {
     var chatData = Dota2.schema.lookupType("CMsgDOTAChatMessage").decode(message);
     var channel = this._getChannelById(chatData.channel_id);
 
+    if (!channel) {
+        channel = { channel_name: "Unknown" }
+    }
+
     this.Logger.debug("Received chat message from " + chatData.persona_name + " in channel " + channel.channel_name);
     this.emit("chatMessage",
         channel.channel_name,


### PR DESCRIPTION
Sometimes the channel is undefined in onChatMessage, this could be due to receiving the message before actually adding the channel to the array of channels so _getChannelById can not find it.

When this happens it throws an error at channel.channel_name, so with this fix we just set the channel_name to be "Unknown"