### PR TITLE
Update protobuf for dotaplus attributes

### DIFF
--- a/proto/dota_gcmessages_common.proto
+++ b/proto/dota_gcmessages_common.proto
@@ -490,6 +490,8 @@ message CMsgDOTAProfileCard {
 	optional .CMsgBattleCupVictory recent_battle_cup_victory = 7;
 	optional uint32 rank_tier = 8;
 	optional uint32 leaderboard_rank = 9;
+	optional uint32 dota_plus = 10;
+	optional uint32 dota_plus_timestamp = 11;
 }
 
 message CSODOTAPlayerChallenge {


### PR DESCRIPTION
I haven't investigated dotaplus changes in other messages. The `dota_plus` key is 1 or 0 depending on whether the user has dotaplus or not. `dota_plus_timestamp` key is just the timestamp at which the user activated dotaplus. 